### PR TITLE
Fix for empty rawdefintions table

### DIFF
--- a/code/cmedecoder/tall_book.q
+++ b/code/cmedecoder/tall_book.q
@@ -27,8 +27,8 @@ qtf:{[x;d]
   };
 
 .cme.tallbook:{[qt]
-  d:exec Symbol!.raw.dfltlvl^MarketDepth from .raw.definitions;
-  setbook[d:max value d];
+  d:exec Symbol!MarketDepth from .raw.definitions;
+  setbook[d:$[0=count d:value d;.raw.dfltlvl;max d]];
   `..book upsert ([] date:"d"$(); time:"p"$(); sym:"s"$(); side:"s"$(); level:"i"$(); orders:"i"$(); size:"f"$(); price:"f"$(); msgseq:"i"$(); rptseq:"i"$();  matchevent:"x"$());
   qtf[;d] each qt;
   }

--- a/code/cmedecoder/tall_book.q
+++ b/code/cmedecoder/tall_book.q
@@ -27,7 +27,7 @@ qtf:{[x;d]
   };
 
 .cme.tallbook:{[qt]
-  d:exec Symbol!MarketDepth from .raw.definitions;
+  d:exec Symbol!.raw.dfltlvl^MarketDepth from .raw.definitions;
   setbook[d:max value d];
   `..book upsert ([] date:"d"$(); time:"p"$(); sym:"s"$(); side:"s"$(); level:"i"$(); orders:"i"$(); size:"f"$(); price:"f"$(); msgseq:"i"$(); rptseq:"i"$();  matchevent:"x"$());
   qtf[;d] each qt;

--- a/code/cmedecoder/wide_book.q
+++ b/code/cmedecoder/wide_book.q
@@ -14,7 +14,7 @@
   `level xasc $[action=`CHANGE;
     state upsert (lvl;sd;px;sz);
    action=`NEW;
-    delete from ((update level+1 from state where level>=lvl,side=sd) upsert (lvl;sd;px;sz)) where level > exec last MarketDepth from .raw.definitions where Symbol = sym;
+    delete from ((update level+1 from state where level>=lvl,side=sd) upsert (lvl;sd;px;sz)) where level > .raw.dfltlvl^exec last MarketDepth from .raw.definitions where Symbol = sym;
    action=`DELETE;
     update level-1 from (delete from state where level=lvl,side=sd) where level>lvl,side=sd;
    action=`DELETETHRU;

--- a/code/processes/cmedecoder.q
+++ b/code/processes/cmedecoder.q
@@ -62,6 +62,7 @@ logfile:{[logfile]
 .lg.o[`load;"Attempting to load existing definitions & status tables"];
 sym:@[get;hsym `$getenv[`DBDIR],"/sym";                                   // attempt to load sym file
       {.lg.w[`load;"Failed to load sym file"]}]                           // warn if unable
+.raw.dfltlvl:10                                                           // Add default Price level, for the case if .raw.definitons is empty
 .raw.definitions:select from @[get;hsym `$getenv[`DBDIR],"/rawdefinitions/";                    // attempt to load existing definitions table for further updates
                                {.lg.w[`load;"No definitions table found"];.schema.definitions}] // warn if unable
 .raw.status:select from @[get;hsym `$getenv[`DBDIR],"/rawstatus/";                              // attempt to load existing status table for further updates


### PR DESCRIPTION
Add .raw.dfltlvl as a default for when rawdefinitons table is empty.
That fills in the 0N values in wide_book and tall_book.
That is what the order book looked before as rawdefinitons table is empty.
![ESH9beforefix](https://user-images.githubusercontent.com/51996872/61445103-9db0f100-a944-11e9-851b-92c9eb8a1c53.jpg)
That is what the order book looks like after filling in the pricelevel in wide_book and tall_book.
![ESH9workingbook](https://user-images.githubusercontent.com/51996872/61445105-9db0f100-a944-11e9-98bb-f513dc993063.jpg)

